### PR TITLE
Fix for issue #2

### DIFF
--- a/lib/generator/sfDoctrineRestGenerator.class.php
+++ b/lib/generator/sfDoctrineRestGenerator.class.php
@@ -47,8 +47,8 @@ class sfDoctrineRestGenerator extends sfGenerator
         {
           $value = trim((string)$value);
           $underscored_name = sfInflector::underscore($name);
-          $payload_array[$underscored_name] = $value;
           unset($payload_array[$name]);
+          $payload_array[$underscored_name] = $value;
         }
         else
         {


### PR DESCRIPTION
Reversed $payload_array assignment and unset calls. See Issue #2: https://github.com/xavierlacot/sfDoctrineRestGeneratorPlugin/issues/2
