### PR TITLE
Small bug fix for values that don't have spaces or need to be underlined

### DIFF
--- a/lib/generator/sfDoctrineRestGenerator.class.php
+++ b/lib/generator/sfDoctrineRestGenerator.class.php
@@ -47,8 +47,8 @@ class sfDoctrineRestGenerator extends sfGenerator
         {
           $value = trim((string)$value);
           $underscored_name = sfInflector::underscore($name);
-          $payload_array[$underscored_name] = $value;
           unset($payload_array[$name]);
+          $payload_array[$underscored_name] = $value;
         }
         else
         {


### PR DESCRIPTION
Fixes a small bug that I came across that will unset a valid payload value

Example:

array('name'=>'some value');
