### PR TITLE
Add functional tests and Location header on entity save

### DIFF
--- a/README
+++ b/README
@@ -17,6 +17,7 @@ for data exchange. Here are some key features :
   * hookable through events and filters
   * abstract and replaceable objects serialization
   * full HTTP support (GET, POST, PUT, DELETE)
+  * functional test for each module generated
 
 
 ## How to install

--- a/README.markdown
+++ b/README.markdown
@@ -17,6 +17,7 @@ for data exchange. Here are some key features :
   * hookable through events and filters
   * abstract and replaceable objects serialization
   * full HTTP support (GET, POST, PUT, DELETE)
+  * functional test for each module generated
 
 
 ## How to install

--- a/data/generator/sfDoctrineRestGenerator/default/parts/createAction.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/createAction.php
@@ -13,6 +13,10 @@
     {
       $content = $request->getParameter('content');
     }
+    if ($content === false)
+    {
+      $content = $request->getPostParameter('content'); // Last chance to get the content!
+    }
 
     $request->setRequestFormat('html');
 

--- a/data/generator/sfDoctrineRestGenerator/default/parts/doSave.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/doSave.php
@@ -1,5 +1,14 @@
   protected function doSave()
   {
     $this->object->save();
+
+    // Set a Location header with the path to the new / updated object
+    $this->getResponse()->setHttpHeader('Location', $this->getController()->genUrl(
+      array_merge(array(
+        'sf_route' => '<?php echo $this->getModuleName(); ?>_show',
+        'sf_format' => $this->getFormat(),
+      ), $this->object->identifier())
+    ));
+
     return sfView::NONE;
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/updateAction.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/updateAction.php
@@ -9,7 +9,7 @@
     $content = $request->getContent();
 
     // Restores backward compatibility. Content can be the HTTP request full body, or a form encoded "content" var.
-    if (strpos($content, 'content=') === 0)
+    if (strpos($content, 'content=') === 0 || $request->hasParameter('content'))
     {
       $content = $request->getParameter('content');
     }

--- a/data/generator/sfDoctrineRestGenerator/default/skeleton/test/actionsTest.php
+++ b/data/generator/sfDoctrineRestGenerator/default/skeleton/test/actionsTest.php
@@ -108,3 +108,7 @@ if ($location)
     end()
   ;
 }
+else
+{
+  $test_browser->test()->fail("The last response doesn't have any Location header!");
+}

--- a/data/generator/sfDoctrineRestGenerator/default/skeleton/test/actionsTest.php
+++ b/data/generator/sfDoctrineRestGenerator/default/skeleton/test/actionsTest.php
@@ -1,0 +1,110 @@
+<?php
+include(dirname(__FILE__).'/../../bootstrap/functional.php');
+
+/**
+ * This is an example class of sfTestFunctional
+ * It may require some attention to work with the default values (line 40).
+ */
+
+$browser           = new sfBrowser();
+$test_browser      = new sfTestFunctional($browser);
+$test_browser->setTester('json.response', 'sfTesterJsonResponse');
+
+$test_browser->
+  get('/##MODULE_NAME##')->
+
+  with('request')->begin()->
+    isParameter('module', '##MODULE_NAME##')->
+    isParameter('action', 'index')->
+  end()->
+
+  with('response')->begin()->
+    isStatusCode(200)->
+  end()->
+
+  with('json.response')->begin()->
+    isJson()->
+  end()
+;
+
+/**
+ * Test the creation
+ */
+$entity         = new ##MODEL_CLASS##();
+$entity_array   = $entity->exportTo('array');
+$identifier     = $entity->getTable()->getIdentifier();
+
+/**
+ * Please build a valid $entity_array here
+ */
+unset($entity_array[$identifier]);
+//$entity_array['name'] = "pony";
+//$entity_array['created_at'] = date('Y-m-d H:i:s');
+//$entity_array['updated_at'] = date('Y-m-d H:i:s');
+
+$test_browser->
+  call('/##MODULE_NAME##', 'post', array('content' => json_encode($entity_array)))->
+
+  with('request')->begin()->
+    isParameter('module', '##MODULE_NAME##')->
+    isParameter('action', 'create')->
+  end()->
+
+  with('response')->begin()->//debug()->
+    isStatusCode(200)->
+  end()
+;
+
+/**
+ * If the new entity has been created
+ */
+$location = $browser->getResponse()->getHttpHeader('Location');
+
+if ($location)
+{
+  // Get ?
+  $test_browser->
+    get($location)->
+
+    with('request')->begin()->
+      isParameter('module', '##MODULE_NAME##')->
+      isParameter('action', 'show')->
+    end()->
+
+    with('response')->begin()->
+      isStatusCode(200)->
+    end()->
+
+    with('json.response')->begin()->
+      isJson()->
+    end()
+  ;
+
+  // Update ?
+  $test_browser->
+    call($location, 'put', array('content' => json_encode($entity_array)))->
+
+    with('request')->begin()->
+      isParameter('module', '##MODULE_NAME##')->
+      isParameter('action', 'update')->
+    end()->
+
+    with('response')->begin()->//debug()->
+      isStatusCode(200)->
+    end()
+  ;
+
+  // Delete ?
+  $test_browser->
+    call($location, 'delete')->
+
+    with('request')->begin()->
+      isParameter('module', '##MODULE_NAME##')->
+      isParameter('action', 'delete')->
+    end()->
+
+    with('response')->begin()->//debug()->
+      isStatusCode(200)->
+    end()
+  ;
+}

--- a/lib/task/sfDoctrineRestGenerateModuleTask.class.php
+++ b/lib/task/sfDoctrineRestGenerateModuleTask.class.php
@@ -44,6 +44,7 @@ EOF;
     // create a route
     $model = $arguments['model'];
     $module = $arguments['module'];
+    $app = $arguments['application'];
 
     $routing = sfConfig::get('sf_app_config_dir').'/routing.yml';
     $content = file_get_contents($routing);
@@ -71,10 +72,10 @@ EOF
       file_put_contents($routing, $content);
     }
 
-    return $this->generate($module, $model);
+    return $this->generate($app, $module, $model);
   }
 
-  protected function generate($module, $model)
+  protected function generate($app, $module, $model)
   {
     $moduleDir = sfConfig::get('sf_app_module_dir').'/'.$module;
 
@@ -110,7 +111,7 @@ EOF
 
     $this->constants = array(
       'PROJECT_NAME'   => isset($properties['symfony']['name']) ? $properties['symfony']['name'] : 'symfony',
-      'APP_NAME'       => $arguments['application'],
+      'APP_NAME'       => $app,
       'MODULE_NAME'    => $module,
       'UC_MODULE_NAME' => ucfirst($module),
       'MODEL_CLASS'    => $model,
@@ -126,6 +127,12 @@ EOF
     ,
       $model
     );
+
     $this->getFilesystem()->replaceTokens($finder->in($moduleDir), '##', '##', $this->constants);
+
+    // Move the fonctionnal test in the sf_test_dir directory
+    $this->getFilesystem()->copy($moduleDir.'/test/actionsTest.php', sfConfig::get('sf_test_dir').'/functional/'.$this->constants['APP_NAME'].'/'.$this->constants['MODULE_NAME'].'ActionsTest.php');
+    $this->getFilesystem()->remove($moduleDir.'/test/actionsTest.php');
+    $this->getFilesystem()->remove($moduleDir.'/test');
   }
 }

--- a/lib/test/sfTesterJsonResponse.class.php
+++ b/lib/test/sfTesterJsonResponse.class.php
@@ -20,14 +20,13 @@ class sfTesterJsonResponse extends sfTester
 
   /**
    * Try to decode the response body from json format
-   * 
+   *
    * @return boolean
    */
   public function isJson()
   {
-    $is_json = (bool) json_decode($this->browser->getResponse()->getContent());
-
-    $is_json ? $this->tester->pass('content is valid json') : $this->tester->fail('content is not valid json');
+    $is_json = json_decode($this->browser->getResponse()->getContent());
+    $is_json !== false ? $this->tester->pass('content is valid json') : $this->tester->fail('content is not valid json');
 
     return $this->getObjectToReturn();
   }

--- a/lib/test/sfTesterJsonResponse.class.php
+++ b/lib/test/sfTesterJsonResponse.class.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * sfTesterJsonResponse implements tests for the symfony response object.
+ */
+class sfTesterJsonResponse extends sfTester
+{
+  /**
+   * Prepares the tester.
+   */
+  public function prepare()
+  {
+  }
+
+  /**
+   * Initializes the tester.
+   */
+  public function initialize()
+  {
+  }
+
+  /**
+   * Try to decode the response body from json format
+   * 
+   * @return boolean
+   */
+  public function isJson()
+  {
+    $is_json = (bool) json_decode($this->browser->getResponse()->getContent());
+
+    $is_json ? $this->tester->pass('content is valid json') : $this->tester->fail('content is not valid json');
+
+    return $this->getObjectToReturn();
+  }
+}


### PR DESCRIPTION
I have added a functional test to the generator skeleton.
It's quite simple and simply test all the available methods.

Some minor changes were necessary to the code too, like 9f3c59d39361c2d22a9427e6ce12fc5e45719e0a and 7372b3a8f9b1ac4349400e26e1cc28cb5994ae60.

I think the tricky part is here: https://github.com/damienalexandre/sfDoctrineRestGeneratorPlugin/blob/master/data/generator/sfDoctrineRestGenerator/default/parts/doSave.php#L6 as I'm not sure this way of generating the route it's the best (not tested with composite key i.e.).

This pull request fix #10 too :)
