### PR TITLE
Major improvements all over the place!

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -22,6 +22,8 @@ for data exchange. Here are some key features :
 
 ## How to install
 
+### Symfony automatic install
+
   * go to your project's root
 
   * Install the plugin:
@@ -33,8 +35,13 @@ for data exchange. Here are some key features :
 
          ./symfony cc
 
+### Using subversion (the code might be older!)
 
-  * alternatively, you might prefer to install this plugin as a Subversion dependancy. In this case, here is the repository: [http://svn.symfony-project.com/plugins/sfDoctrineRestGeneratorPlugin](http://svn.symfony-project.com/plugins/sfDoctrineRestGeneratorPlugin). There is also a Git mirror on GitHub : [https://github.com/xavierlacot/sfDoctrineRestGeneratorPlugin](https://github.com/xavierlacot/sfDoctrineRestGeneratorPlugin)
+  * [http://svn.symfony-project.com/plugins/sfDoctrineRestGeneratorPlugin](http://svn.symfony-project.com/plugins/sfDoctrineRestGeneratorPlugin).
+
+#### Using git
+
+  * [https://github.com/xavierlacot/sfDoctrineRestGeneratorPlugin](https://github.com/xavierlacot/sfDoctrineRestGeneratorPlugin)
 
 ## Usage
 
@@ -78,7 +85,7 @@ If we want to expose the model "Post" through a REST API, we will simply type
 the command:
 
 
-        ./symfony doctrine:generate-rest-module  api post Post
+        ./symfony doctrine:generate-rest-module api post Post
 
 
 This will generate:
@@ -100,6 +107,8 @@ This will generate:
    * lib: contains an empty "postGeneratorConfiguration" class, which extends a on-the-fly generated "BasePostGeneratorConfiguration" class,
    * templates
 
+ * a lime functional test skeleton in /test/functional/api
+
  * after a first request has been made to the REST module, the cache directory will contain the code of the generated module, and particularly the code of the "autopostActions" class, which you should check in order to understand the way the plugin works.
 
 
@@ -119,7 +128,6 @@ http://api.example.com/myPostAPI.json:
              module:  post
              column:  id
              format:  xml
-
 
 
 ## Main configuration
@@ -161,7 +169,8 @@ Second, consider a way to make your webservice more secure:
  * use SSL whenever possible, so that the posted data do not get intercepted and altered by a third party (man in the middle),
  * use HTTP authentication,
  * use a stronger / more extensible authentication system (OAuth for example),
- * deliver unique API keys to your clients, and check the usage that they do of the API.
+ * deliver unique API keys to your clients, and check the usage that they do of the API,
+ * improve the generated validators with your own business rules
 
 
 ## Detailed service configuration
@@ -175,7 +184,7 @@ Here is the default content of the `generator.yml` file:
           class: sfDoctrineRestGenerator
           param:
             model_class:   Post
-
+        #    actions_base_class: sfActions
             config:
               default:
         #        fields:                                # list here the fields.
@@ -183,6 +192,9 @@ Here is the default content of the `generator.yml` file:
         #        formats_enabled:               [ json, xml, yaml ]    # enabled formats
         #        formats_strict:                true
         #        separator:                     ','     # separator used for multiple filters
+        #        camelize:                      true    # tell the serializers to translate fieldnames to camelCase
+        #        root_name:                     ##MODEL_CLASS##  # the root node name used for serilize one ressource
+        #        plural_root_name:              false   # you can overide the plural root node name (if false, we add a "s" to root_name)
               get:
         #        additional_params:             []      # list here additional params names, which are not object properties
         #        default_format:                json    # the default format of the response. If not set, will default to json. Accepted values are  "json", "xml" or "yaml"
@@ -210,6 +222,11 @@ detailed in the following chapters.
 
 The `model_class` parameters defines the name of the Doctrine model the REST
 module is bound to.
+
+### actions_base_class
+
+All the generated controllers will extend this class.
+
 
 ### default
 
@@ -256,11 +273,26 @@ The separator to use in url when passing objects primary keys. The generated
 module allows to require several resources identified by their ids:
 http://api.example.com/post/?id=12,17,19
 
+        #        camelize:                      true    # tell the serializers to translate fieldnames to camelCase
+        #        root_name:                     ##MODEL_CLASS##  # the root node name used for serilize one ressource
+        #        plural_root_name:              false   # you can overide the plural root node name (if false, we add a "s" to root_name)
+
+### camelize
+
+On serialization, your fieldnames will be camelCased by default (only XML atm).
+
+### root_name
+
+You can customize the root_name of the Json / Xml outputs (by default, it's the model name).
+
+### plural_root_name
+
+By default, collections of ressources are put in a "s" suffixed model name. But for a Company model, you don't want to have a `Companys` XML root name. Simply write your own here.
+
 
 ### get
 
 The `get` option lists several options specific to the "get" operation:
-
 
 #### additional_params
 
@@ -591,11 +623,12 @@ picking one of the following topics:
  * possibility to disable events notification / filtering (performance)
  * more serializers ([BSON](http://bsonspec.org/) or RDF for example). Currently, the plugin only allows to serialize the resultsets as a XML, YAML or JSON feeds (see the chapter "Serialization"). Mobile clients, which require the most compact possible streams, would take benefit from a BSON serialization.
  * possibility to generate client libraries (sfDoctrineRestClientGenerator ?)
- * possibility to generate unit tests
  * possibility to generate API documentation
  * document authentication solutions
  * all the possible feedback!
-
+ * recode the post validators logic (to use the full params array on each post validator, same as sfForm)
+ * camelize on all the serializer? (only XML do that atm)
+ * don't use the templating system (performance)
 
 ## Contribute to the plugin, ask for help
 
@@ -611,10 +644,20 @@ licensed under the MIT license.
 
 ## Changelog
 
-### trunk
+### master on damienalexandre/sfDoctrineRestGeneratorPlugin
+
+ * Improve the XML and Json serializer (deal with collections, plural naming, Json and XML are now a lot more consistant)
+ * Add a `camelize` option
+ * Add a `root_name` option
+ * Add a `plural_root_name` option
+ * Use the query() method in update and delete action (you can now have consistent query on all methods)
+ * The validated payload array is now kept and send to updateObjectFromRequest(). This is allowing a lot of flexibility (like saving sfValidatedFile instance i.e.)
+ * Add a dynamically generated functional test on each new module
+ * Add a `location` header on create and update response with the uri to the new ressource
+
+### master
 
  * Enabled the `show` route by default
-
 
 ### version 0.9.4 - 2010-11-25
 

--- a/data/generator/sfDoctrineRestGenerator/default/parts/configuration.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/configuration.php
@@ -100,6 +100,12 @@ abstract class Base<?php echo ucfirst($this->getModuleName()) ?>GeneratorConfigu
 <?php unset($this->config['default']['root_name']) ?>
   }
 
+  public function getPluralRootName()
+  {
+    return <?php echo $this->asPhp(isset($this->config['default']['plural_root_name']) ? $this->config['default']['plural_root_name'] : false) ?>;
+<?php unset($this->config['default']['plural_root_name']) ?>
+  }
+
 <?php include dirname(__FILE__).'/paginationConfiguration.php' ?>
 
 <?php include dirname(__FILE__).'/sortConfiguration.php' ?>

--- a/data/generator/sfDoctrineRestGenerator/default/parts/configuration.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/configuration.php
@@ -91,6 +91,12 @@ abstract class Base<?php echo ucfirst($this->getModuleName()) ?>GeneratorConfigu
 <?php unset($this->config['default']['separator']) ?>
   }
 
+  public function getCamelize()
+  {
+    return <?php echo $this->asPhp(isset($this->config['default']['camelize']) ? $this->config['default']['camelize'] : true) ?>;
+<?php unset($this->config['default']['camelize']) ?>
+  }
+
 <?php include dirname(__FILE__).'/paginationConfiguration.php' ?>
 
 <?php include dirname(__FILE__).'/sortConfiguration.php' ?>

--- a/data/generator/sfDoctrineRestGenerator/default/parts/configuration.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/configuration.php
@@ -3,10 +3,7 @@
 /**
  * <?php echo $this->getModuleName() ?> module configuration.
  *
- * @package    ##PROJECT_NAME##
  * @subpackage <?php echo $this->getModuleName()."\n" ?>
- * @author     ##AUTHOR_NAME##
- * @version    SVN: $Id: configuration.php 24171 2009-11-19 16:37:50Z Kris.Wallsmith $
  */
 abstract class Base<?php echo ucfirst($this->getModuleName()) ?>GeneratorConfiguration extends sfDoctrineRestGeneratorConfiguration
 {
@@ -95,6 +92,12 @@ abstract class Base<?php echo ucfirst($this->getModuleName()) ?>GeneratorConfigu
   {
     return <?php echo $this->asPhp(isset($this->config['default']['camelize']) ? $this->config['default']['camelize'] : true) ?>;
 <?php unset($this->config['default']['camelize']) ?>
+  }
+
+  public function getRootName()
+  {
+    return <?php echo $this->asPhp(isset($this->config['default']['root_name']) ? $this->config['default']['root_name'] : $this->getModelClass()) ?>;
+<?php unset($this->config['default']['root_name']) ?>
   }
 
 <?php include dirname(__FILE__).'/paginationConfiguration.php' ?>

--- a/data/generator/sfDoctrineRestGenerator/default/parts/createAction.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/createAction.php
@@ -22,7 +22,8 @@
 
     try
     {
-      $this->validateCreate($content);
+      $params = $this->parsePayload($content);
+      $params = $this->validateCreate($params);
     }
     catch (Exception $e)
     {
@@ -52,6 +53,6 @@
     }
 
     $this->object = $this->createObject();
-    $this->updateObjectFromRequest($content);
+    $this->updateObjectFromRequest($params);
     return $this->doSave();
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/deleteAction.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/deleteAction.php
@@ -10,7 +10,7 @@
     $this->forward404Unless($request->isMethod(sfRequest::DELETE));
     $primaryKey = $request->getParameter('<?php echo $primaryKey ?>');
     $this->forward404Unless($primaryKey);
-    $this->item = Doctrine::getTable($this->model)->findOneBy<?php echo sfInflector::camelize($primaryKey) ?>($primaryKey);
+    $this->item = $this->query(array('<?php echo $primaryKey ?>' => $primaryKey))->fetchOne();
     $this->forward404Unless($this->item);
     $this->item->delete();
     return sfView::NONE;

--- a/data/generator/sfDoctrineRestGenerator/default/parts/doSave.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/doSave.php
@@ -2,6 +2,7 @@
   {
     $this->object->save();
 
+<?php $primaryKey = $this->configuration->getValue('default.update_key', Doctrine::getTable($this->getModelClass())->getIdentifier()); ?>
     // Set a Location header with the path to the new / updated object
     $this->getResponse()->setHttpHeader('Location', $this->getController()->genUrl(
       array_merge(array(

--- a/data/generator/sfDoctrineRestGenerator/default/parts/getIndexValidators.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/getIndexValidators.php
@@ -20,13 +20,13 @@ $max_items = $this->configuration->getValue('get.max_items'); ?>
       'max' => <?php echo $max_items ?>,
       'required' => false
     );
-    $validators['pagesize'] = new sfValidatorInteger($params);
+    $validators['page_size'] = new sfValidatorInteger($params);
 <?php endif; ?>
 <?php endif; ?>
 <?php $sort_custom = $this->configuration->getValue('get.sort_custom'); ?>
 <?php if ($sort_custom): ?>
-    $validators['orderby'] = new sfValidatorChoice(array('choices' => <?php echo var_export($this->table->getColumnNames()) ?>, 'required' => false));
-    $validators['sortorder'] = new sfValidatorChoice(array('choices' => array('asc', 'desc'), 'required' => false));
+    $validators['sort_by'] = new sfValidatorChoice(array('choices' => <?php echo var_export($this->table->getColumnNames()) ?>, 'required' => false));
+    $validators['sort_order'] = new sfValidatorChoice(array('choices' => array('asc', 'desc'), 'required' => false));
 <?php endif; ?>
 <?php $additional_params = $this->configuration->getValue('get.additional_params'); ?>
 <?php if ($additional_params): ?>

--- a/data/generator/sfDoctrineRestGenerator/default/parts/getIndexValidators.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/getIndexValidators.php
@@ -20,13 +20,13 @@ $max_items = $this->configuration->getValue('get.max_items'); ?>
       'max' => <?php echo $max_items ?>,
       'required' => false
     );
-    $validators['page_size'] = new sfValidatorInteger($params);
+    $validators['pagesize'] = new sfValidatorInteger($params);
 <?php endif; ?>
 <?php endif; ?>
 <?php $sort_custom = $this->configuration->getValue('get.sort_custom'); ?>
 <?php if ($sort_custom): ?>
-    $validators['sort_by'] = new sfValidatorChoice(array('choices' => <?php echo var_export($this->table->getColumnNames()) ?>, 'required' => false));
-    $validators['sort_order'] = new sfValidatorChoice(array('choices' => array('asc', 'desc'), 'required' => false));
+    $validators['orderby'] = new sfValidatorChoice(array('choices' => <?php echo var_export($this->table->getColumnNames()) ?>, 'required' => false));
+    $validators['sortorder'] = new sfValidatorChoice(array('choices' => array('asc', 'desc'), 'required' => false));
 <?php endif; ?>
 <?php $additional_params = $this->configuration->getValue('get.additional_params'); ?>
 <?php if ($additional_params): ?>

--- a/data/generator/sfDoctrineRestGenerator/default/parts/getSerializer.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/getSerializer.php
@@ -4,11 +4,11 @@
     {
       try
       {
-        $this->serializer = sfResourceSerializer::getInstance($this->getFormat());
+        $this->serializer = sfResourceSerializer::getInstance($this->getFormat(), <?php echo $this->asPhp($this->configuration->getValue('default.camelize')) ?>);
       }
       catch (sfException $e)
       {
-        $this->serializer = sfResourceSerializer::getInstance('<?php echo $this->configuration->getValue('get.default_format') ?>');
+        $this->serializer = sfResourceSerializer::getInstance('<?php echo $this->configuration->getValue('get.default_format') ?>', <?php echo $this->asPhp($this->configuration->getValue('default.camelize')) ?>);
         throw new sfException($e->getMessage());
       }
     }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/indexAction.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/indexAction.php
@@ -17,7 +17,7 @@
     try
     {
       $format = $this->getFormat();
-      $this->validateIndex($params);
+      $params = $this->validateIndex($params);
     }
     catch (Exception $e)
     {
@@ -82,6 +82,6 @@
 
     $serializer = $this->getSerializer();
     $this->getResponse()->setContentType($serializer->getContentType());
-    $this->output = $serializer->serialize($this->objects, <?php echo $this->asPhp($this->configuration->getValue('default.root_name')); ?>);
+    $this->output = $serializer->serialize($this->objects, <?php echo $this->asPhp($this->configuration->getValue('default.root_name')); ?>, true, <?php echo $this->asPhp($this->configuration->getValue('default.plural_root_name')); ?>);
     unset($this->objects);
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/indexAction.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/indexAction.php
@@ -82,6 +82,6 @@
 
     $serializer = $this->getSerializer();
     $this->getResponse()->setContentType($serializer->getContentType());
-    $this->output = $serializer->serialize($this->objects, $this->model);
+    $this->output = $serializer->serialize($this->objects, <?php echo $this->asPhp($this->configuration->getValue('default.root_name')); ?>);
     unset($this->objects);
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/parsePayload.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/parsePayload.php
@@ -10,7 +10,7 @@
         $payload_array = $serializer->unserialize($payload);
       }
 
-      if (!isset($payload_array) || !$payload_array)
+      if (!isset($payload_array) || $payload_array === false)
       {
         throw new sfException(sprintf('Could not parse payload, obviously not a valid %s data!', $format));
       }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/showAction.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/showAction.php
@@ -61,6 +61,6 @@
 
     $serializer = $this->getSerializer();
     $this->getResponse()->setContentType($serializer->getContentType());
-    $this->output = $serializer->serialize($this->objects[0], $this->model, false);
+    $this->output = $serializer->serialize($this->objects[0], <?php echo $this->asPhp($this->configuration->getValue('default.root_name')); ?>, false);
     unset($this->objects);
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/showAction.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/showAction.php
@@ -47,7 +47,7 @@
     }
 
     $this->queryFetchOne($params);
-    $this->forward404Unless(is_array($this->objects[0]));
+    $this->forward404Unless(is_array($this->objects[0]) && !empty($this->objects[0]));
 
 <?php foreach ($this->configuration->getValue('get.object_additional_fields') as $field): ?>
     $this->embedAdditional<?php echo $field ?>(0, $params);

--- a/data/generator/sfDoctrineRestGenerator/default/parts/updateAction.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/updateAction.php
@@ -16,9 +16,16 @@
 
     $request->setRequestFormat('html');
 
+    // retrieve the object
+<?php $primaryKey = Doctrine_Core::getTable($this->getModelClass())->getIdentifier() ?>
+    $primaryKey = $request->getParameter('<?php echo $primaryKey ?>');
+    $this->object = $this->query(array('<?php echo $primaryKey ?>' => $primaryKey))->fetchOne();
+    $this->forward404Unless($this->object);
+
     try
     {
-      $this->validateUpdate($content);
+      $params = $this->parsePayload($content);
+      $params = $this->validateUpdate($params);
     }
     catch (Exception $e)
     {
@@ -47,13 +54,7 @@
       return sfView::SUCCESS;
     }
 
-    // retrieve the object
-<?php $primaryKey = Doctrine_Core::getTable($this->getModelClass())->getIdentifier() ?>
-    $primaryKey = $request->getParameter('<?php echo $primaryKey ?>');
-    $this->object = Doctrine_Core::getTable($this->model)->findOneBy<?php echo sfInflector::camelize($primaryKey) ?>($primaryKey);
-    $this->forward404Unless($this->object);
-
     // update and save it
-    $this->updateObjectFromRequest($content);
+    $this->updateObjectFromRequest($params);
     return $this->doSave();
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/updateObjectFromRequest.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/updateObjectFromRequest.php
@@ -1,4 +1,4 @@
-  protected function updateObjectFromRequest($content)
+  protected function updateObjectFromRequest($params)
   {
-    $this->object->importFrom('array', $this->parsePayload($content));
+    $this->object->importFrom('array', $params);
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/validate.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/validate.php
@@ -1,5 +1,6 @@
   /**
    * Applies a set of validators to an array of parameters
+   * The cleaned value replace
    *
    * @param array   $params      An array of parameters
    * @param array   $validators  An array of validators
@@ -7,6 +8,12 @@
    */
   public function validate($params, $validators, $prefix = '')
   {
+    if ($params === null && is_array($validators))
+    {
+      // The case of an empty collection
+      return null;
+    }
+    
     $unused = array_keys($validators);
 
     foreach ($params as $name => $value)
@@ -19,12 +26,31 @@
       {
         if (is_array($validators[$name]))
         {
-          // validator for a related object
-          $this->validate($value, $validators[$name], $prefix.$name.'.');
+          if (is_array($value) && isset($value[0]))
+          {
+            // We are on a list of array, not a related object
+            foreach ($value as $key => $val)
+            {
+              $params[$name][$key] = $this->validate($val, $validators[$name], $prefix.$name.'.');
+            }
+          }
+          else
+          {
+            // validator for a related object
+            $params[$name] = $this->validate($value, $validators[$name], $prefix.$name.'.');
+          }
+        }
+        elseif (is_array($value) && isset($value[0]) && $validators[$name] instanceof sfValidatorBase)
+        {
+          // We are on a list of value
+          foreach ($value as $key => $val)
+          {
+            $params[$name][$key] = $validators[$name]->clean($val);
+          }
         }
         else
         {
-          $validators[$name]->clean($value);
+          $params[$name] = $validators[$name]->clean($value);
         }
 
         unset($unused[array_search($name, $unused, true)]);
@@ -46,4 +72,6 @@
         throw new sfException(sprintf('Could not validate field "%s": %s', $prefix.$name, $e->getMessage()));
       }
     }
+
+    return $params;
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/validateCreate.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/validateCreate.php
@@ -1,15 +1,16 @@
   /**
    * Applies the creation validators to the payload posted to the service
    *
-   * @param   string   $payload  A payload string
+   * @param   array   $params  A parsed payload array
+   * @return  array   $params  A cleaned params array
    */
-  public function validateCreate($payload)
+  public function validateCreate($params)
   {
-    $params = $this->parsePayload($payload);
-
     $validators = $this->getCreateValidators();
-    $this->validate($params, $validators);
+    $params = $this->validate($params, $validators);
 
     $postvalidators = $this->getCreatePostValidators();
     $this->postValidate($params, $postvalidators);
+
+    return $params;
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/validateIndex.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/validateIndex.php
@@ -3,12 +3,15 @@
    * webservice
    *
    * @param   array   $params  An array of criterions used for the selection
+   * @return  array   A cleaned array of criterions
    */
   public function validateIndex($params)
   {
     $validators = $this->getIndexValidators();
-    $this->validate($params, $validators);
+    $params = $this->validate($params, $validators);
 
     $postvalidators = $this->getIndexPostValidators();
     $this->postValidate($params, $postvalidators);
+
+    return $params;
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/validateUpdate.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/validateUpdate.php
@@ -1,15 +1,16 @@
   /**
    * Applies the update validators to the payload posted to the service
    *
-   * @param   string   $payload  A payload string
+   * @param   array   $params  A parsed payload array
+   * @return  array   $params  A cleaned params array
    */
-  public function validateUpdate($payload)
+  public function validateUpdate($params)
   {
-    $params = $this->parsePayload($payload);
-
     $validators = $this->getUpdateValidators();
-    $this->validate($params, $validators);
+    $params = $this->validate($params, $validators);
 
     $postvalidators = $this->getUpdatePostValidators();
     $this->postValidate($params, $postvalidators);
+
+    return $params;
   }

--- a/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
+++ b/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
@@ -12,6 +12,7 @@ generator:
 #        separator:                     ','     # separator used for multiple filters
 #        camelize:                      true
 #        root_name:                     ##MODEL_CLASS##
+#        plural_root_name:              false   # you can overide the plural root node name (if false, we add a "s" to root_name)
       get:
 #        additional_params:             []      # list here additionnal params names, which are not object properties
 #        default_format:                json    # the default format of the response. If not set, will default to json. accepted values are "json", "xml" or "yaml"
@@ -26,7 +27,7 @@ generator:
 #        pagination_enabled:            false   # set to true to activate the pagination
 #        pagination_custom_page_size:   false   # set to true to allow the client to pass a page_size parameter
 #        pagination_page_size:          100     # the default number of items in a page
-#        sort_custom:                   false   # set to true to allow the client to pass a sort_by and a sort_order parameter
+#        sort_custom:                   false   # set to true to allow the client to pass a orderby and a sortorder parameter
 #        sort_default:                  []      # set to [column, asc|desc] in order to sort on a column
 #        filters:                               # list here the filters
 #          created_at:                  { date_format: 'd-m-Y', multiple: true }  # for instance

--- a/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
+++ b/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
@@ -2,7 +2,7 @@ generator:
   class: sfDoctrineRestGenerator
   param:
     model_class:   ##MODEL_CLASS##
-
+#    actions_base_class: sfActions
     config:
       default:
 #        fields:                                # list here the fields.
@@ -10,8 +10,8 @@ generator:
 #        formats_enabled:               [ json, xml, yaml ]    # enabled formats
 #        formats_strict:                true
 #        separator:                     ','     # separator used for multiple filters
-#        camelize:                      true
-#        root_name:                     ##MODEL_CLASS##
+#        camelize:                      true    # tell the serializers to translate fieldnames to camelCase
+#        root_name:                     ##MODEL_CLASS##  # the root node name used for serilize one ressource
 #        plural_root_name:              false   # you can overide the plural root node name (if false, we add a "s" to root_name)
       get:
 #        additional_params:             []      # list here additionnal params names, which are not object properties

--- a/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
+++ b/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
@@ -10,6 +10,7 @@ generator:
 #        formats_enabled:               [ json, xml, yaml ]    # enabled formats
 #        formats_strict:                true
 #        separator:                     ','     # separator used for multiple filters
+#        camelize:                      true
       get:
 #        additional_params:             []      # list here additionnal params names, which are not object properties
 #        default_format:                json    # the default format of the response. If not set, will default to json. accepted values are "json", "xml" or "yaml"

--- a/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
+++ b/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
@@ -11,6 +11,7 @@ generator:
 #        formats_strict:                true
 #        separator:                     ','     # separator used for multiple filters
 #        camelize:                      true
+#        root_name:                     ##MODEL_CLASS##
       get:
 #        additional_params:             []      # list here additionnal params names, which are not object properties
 #        default_format:                json    # the default format of the response. If not set, will default to json. accepted values are "json", "xml" or "yaml"

--- a/lib/generator/sfDoctrineRestGeneratorConfiguration.class.php
+++ b/lib/generator/sfDoctrineRestGeneratorConfiguration.class.php
@@ -21,7 +21,8 @@ class sfDoctrineRestGeneratorConfiguration
         'formats_enabled'             => $this->getFormatsEnabled(),
         'formats_strict'              => $this->getFormatsStrict(),
         'separator'                   => $this->getSeparator(),
-        'camelize'                    => $this->getCamelize()
+        'camelize'                    => $this->getCamelize(),
+        'root_name'                   => $this->getRootName(),
       ),
       'get'     => array(
         'additional_params'           => $this->getAdditionalParams(),

--- a/lib/generator/sfDoctrineRestGeneratorConfiguration.class.php
+++ b/lib/generator/sfDoctrineRestGeneratorConfiguration.class.php
@@ -20,7 +20,8 @@ class sfDoctrineRestGeneratorConfiguration
         'fields'                      => $this->getFieldsDefault(),
         'formats_enabled'             => $this->getFormatsEnabled(),
         'formats_strict'              => $this->getFormatsStrict(),
-        'separator'                   => $this->getSeparator()
+        'separator'                   => $this->getSeparator(),
+        'camelize'                    => $this->getCamelize()
       ),
       'get'     => array(
         'additional_params'           => $this->getAdditionalParams(),

--- a/lib/serializer/sfResourceSerializer.class.php
+++ b/lib/serializer/sfResourceSerializer.class.php
@@ -2,6 +2,8 @@
 
 abstract class sfResourceSerializer
 {
+  private $camelize = true;
+  
   abstract public function getContentType();
 
   /**
@@ -11,21 +13,39 @@ abstract class sfResourceSerializer
    * @author CakePHP
    * @see http://book.cakephp.org/view/572/Class-methods
    * @param  string $string  The string to camelize
-   * @return string with CamelCase
+   * @return string with CamelCase or underscored depending on configuration
    */
   protected function camelize($string)
   {
-    return str_replace(" ", "", ucwords(str_replace("_", " ", $string)));
+    if ($this->camelize)
+    {
+      return str_replace(" ", "", ucwords(str_replace("_", " ", $string)));
+    }
+    else
+    {
+      return sfInflector::underscore($string);
+    }
   }
 
   /**
-   * Creates an instance of a seriazlizer
+   * Tell the serializer to camelize names or to let them flat
+   * 
+   * @param boolean $camelize
+   */
+  public function setCamelize($camelize)
+  {
+    $this->camelize = $camelize;
+  }
+
+  /**
+   * Creates an instance of a serializer
    *
    * @param  string  $format   The serializer format (xml, json, etc.)
+   * @param  boolean $camelize Tell the serializer to Camelize nodes
    * @return object  a serializer object
    * @throws sfException
    */
-  public static function getInstance($format = 'xml')
+  public static function getInstance($format = 'xml', $camelize = true)
   {
     $classname = sprintf('sfResourceSerializer%s', ucfirst($format));
 
@@ -34,7 +54,9 @@ abstract class sfResourceSerializer
       throw new sfException(sprintf('Could not find seriaizer "%s"', $classname));
     }
 
-    return new $classname;
+    $serializer = new $classname;
+    $serializer->setCamelize($camelize);
+    return $serializer;
   }
 
   abstract public function serialize($array, $rootNodeName = 'data', $collection = true);

--- a/lib/serializer/sfResourceSerializer.class.php
+++ b/lib/serializer/sfResourceSerializer.class.php
@@ -59,6 +59,6 @@ abstract class sfResourceSerializer
     return $serializer;
   }
 
-  abstract public function serialize($array, $rootNodeName = 'data', $collection = true);
+  abstract public function serialize($array, $rootNodeName = 'data', $collection = true, $plural_root_name = false);
   abstract public function unserialize($payload);
 }

--- a/lib/serializer/sfResourceSerializerJson.class.php
+++ b/lib/serializer/sfResourceSerializerJson.class.php
@@ -1,5 +1,9 @@
 <?php
-
+/**
+ * Custom Json Serializer for sfDoctrineRestGeneratorPlugin
+ *
+ * @author dalexandre
+ */
 class sfResourceSerializerJson extends sfResourceSerializer
 {
   public function getContentType()
@@ -7,13 +11,92 @@ class sfResourceSerializerJson extends sfResourceSerializer
     return 'application/json';
   }
 
-  public function serialize($array, $rootNodeName = 'data', $collection = true)
+  public function serialize($array, $rootNodeName = 'data', $collection = true, $pluralRootNodeName = false)
   {
+    if ($collection)
+    {
+      foreach ($array as $key => $result)
+      {
+        $array[$key] = array($rootNodeName => $result);
+      }
+
+      if ($pluralRootNodeName)
+      {
+        $array = array($pluralRootNodeName => $this->pluralizeCollections($array));
+      }
+      else
+      {
+        $array = array($rootNodeName.'s' => $this->pluralizeCollections($array));
+      }
+    }
+    else
+    {
+      $array = array($rootNodeName => $this->pluralizeCollections($array));
+    }
+
     return json_encode($array);
+  }
+
+  /**
+   * Mimic the XML behavior for Json serialization
+   *
+   * @param array $array
+   * @return array
+   */
+  public function pluralizeCollections($array)
+  {
+    foreach ($array as $key => $nodes)
+    {
+      if (is_array($nodes) && isset($nodes[0]))
+      {
+        foreach ($nodes as $noderesult)
+        {
+          $array[$key.'s'][] = array($key => $noderesult);
+        }
+        unset($array[$key]);
+      }
+      elseif (is_array($nodes))
+      {
+        $array[$key] = $this->pluralizeCollections($nodes);
+      }
+    }
+    return $array;
   }
 
   public function unserialize($payload)
   {
-    return json_decode($payload, true);
+    $array = json_decode($payload, true);
+    if ($array)
+    {
+      $array = array_shift($array);
+    }
+
+    $array = $this->unPluralizeCollections($array);
+
+    //var_dump($array['languages']);die();
+
+    return $array;
+  }
+
+  public function unPluralizeCollections($array)
+  {
+    foreach ($array as $key => $nodes)
+    {
+      if (is_array($nodes) && isset($nodes[0]))
+      {
+        $group_name = key($nodes[0]);
+
+        foreach ($nodes as $nodekey => $noderesult)
+        {
+          unset($array[$key][$nodekey]);
+          $array[$key][$group_name][] = $noderesult[$group_name];
+        }
+      }
+      elseif (is_array($nodes))
+      {
+        $array[$key] = $this->unPluralizeCollections($nodes);
+      }
+    }
+    return $array;
   }
 }

--- a/lib/serializer/sfResourceSerializerJson.class.php
+++ b/lib/serializer/sfResourceSerializerJson.class.php
@@ -73,11 +73,15 @@ class sfResourceSerializerJson extends sfResourceSerializer
 
     $array = $this->unPluralizeCollections($array);
 
-    //var_dump($array['languages']);die();
-
     return $array;
   }
 
+  /**
+   * Deal with collections
+   * 
+   * @param array $array
+   * @return array
+   */
   public function unPluralizeCollections($array)
   {
     foreach ($array as $key => $nodes)

--- a/lib/serializer/sfResourceSerializerYaml.class.php
+++ b/lib/serializer/sfResourceSerializerYaml.class.php
@@ -7,7 +7,7 @@ class sfResourceSerializerYaml extends sfResourceSerializer
     return 'application/yaml';
   }
 
-  public function serialize($array, $rootNodeName = 'data', $collection = true)
+  public function serialize($array, $rootNodeName = 'data', $collection = true, $pluralRootNodeName = false)
   {
     return sfYaml::dump(array($rootNodeName => $array), 5);
   }

--- a/lib/test/sfTesterJsonResponse.class.php
+++ b/lib/test/sfTesterJsonResponse.class.php
@@ -20,7 +20,7 @@ class sfTesterJsonResponse extends sfTester
 
   /**
    * Try to decode the response body from json format
-   *
+   * 
    * @return boolean
    */
   public function isJson()


### PR DESCRIPTION
I have some work to contribute on the plugin:
- Improve the XML and Json serializer (deal with collections, plural naming, Json and XML are now a lot more consistant)
- Add a `camelize` option
- Add a `root_name` option
- Add a `plural_root_name` option
- Use the query() method in update and delete action (you can now have consistent query on all methods)
- The validated payload array is now kept and send to updateObjectFromRequest(). This is allowing a lot of flexibility (like saving sfValidatedFile instance i.e.)
- Updated documentation!

BUT we still need to do some stuff before a 1.0 release imho: 
- recode the post validators logic (to use the full params array on each post validator, same as sfForm)
- camelize on all the serializer? (only XML do that atm)
- don't use the templating system (performance)
- add phpunit test to test the plugin itself (the serializer)

The main issue will be merging my Xml Serializer changes with the ones done in 4ba92e2460aec7288d5800d88d56b8745ad0bdda, unit test can help.

I know symfony standard is lime (and that's why the generated functional test are lime one's) but as plugin developper we can use PhpUnit (which is way more efficient and dev friendly).
What do you think about that?

I could work on some test but I'm asking; lime or phpunit? 

Have fun merging those stuffs ;-) Cheer.
