### PR TITLE
Add type casting to generated module

### DIFF
--- a/README
+++ b/README
@@ -222,6 +222,7 @@ decoration options that are used during the (de-)serialization. It might be:
 
   * `date_format`: the date format to use when formatting the field. This must be a format acceptable for the date() function,
   * `tag_name`: the tag name to use for displaying this field. For instance, you might want to associate the title of the post to the key "post_title", and not "title".
+  * `type`: the type to use for displaying this field. All [php cast keywords](http://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting) are supported, null values are retained.
 
 
 #### formats_enabled

--- a/README.markdown
+++ b/README.markdown
@@ -222,6 +222,7 @@ decoration options that are used during the (de-)serialization. It might be:
 
   * `date_format`: the date format to use when formatting the field. This must be a format acceptable for the date() function,
   * `tag_name`: the tag name to use for displaying this field. For instance, you might want to associate the title of the post to the key "post_title", and not "title".
+  * `type`: the type to use for displaying this field. All [php cast keywords](http://www.php.net/manual/en/language.types.type-juggling.php#language.types.typecasting) are supported, null values are retained.
 
 
 #### formats_enabled

--- a/data/generator/sfDoctrineRestGenerator/default/parts/configureFields.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/configureFields.php
@@ -24,11 +24,14 @@ foreach ($fields as $field => $configuration)
     foreach ($this->objects as $i => $object)
     {
 <?php foreach ($fields as $field => $configuration): ?>
-<?php if (isset($configuration['date_format']) || isset($configuration['tag_name'])): ?>
+<?php if (isset($configuration['date_format']) || isset($configuration['tag_name']) || isset($configuration['type'])): ?>
       if (isset($object['<?php echo $field ?>']))
       {
 <?php if (isset($configuration['date_format'])): ?>
         $object['<?php echo $field ?>'] = date('<?php echo $configuration['date_format'] ?>', strtotime($object['<?php echo $field ?>']));
+<?php endif; ?>
+<?php if (isset($configuration['type'])): ?>
+	     $object['<?php echo $field ?>'] = is_null($object['<?php echo $field ?>']) ? null : (<?php echo $configuration['type'] ?>) $object['<?php echo $field ?>'];
 <?php endif; ?>
 <?php if (isset($configuration['tag_name'])): ?>
         $object['<?php echo $configuration['tag_name'] ?>'] = $object['<?php echo $field ?>'];


### PR DESCRIPTION
In many cases it is desirable that an API exposes type information about the fields in that endpoint. JSON and YAML have possibilities for this type information (compare `{ "id": "12" }` and `{ "id": 12 }`)
This PR adds the possibility of setting types on fields in `generator.yml`
