### PR TITLE
Allow custom embedding of relations

### DIFF
--- a/README
+++ b/README
@@ -341,6 +341,38 @@ Several things to consider:
   * The response contains both the `PostCategoryId` field and the `PostCategory.Id` fields. You can save some bytes by using the `display` or the `hide` options, in order to remove the `PostCategoryId` field.
 
 
+#### embed_relations_custom
+
+The `embed_relations_custom` option contains a list of Doctrine relations that
+may be embedded. These relations will only be embedded if the `embed` parameter
+is present in the request. The behavior is consistent with the `embed_relations`
+option. Here is a valid configuration for our "Post" model:
+
+            config:
+              get:
+                embed_relations_custom:                [ PostCategory ]
+
+If the `embed` request parameter is given, this configuration will produce a
+feed like:
+
+    ...
+    <Post>
+      <Id>1</Id>
+      <PostCategoryId>2</PostCategoryId>
+      <CreatedBy>26</CreatedBy>
+      <Title>Here the title of my post</Title>
+      <Summary>Here the summary of my post</Summary>
+      <Body>Here the body of my post</Body>
+      <PostCategory>
+        <Id>2</Id>
+        <Name>Name of the category</Name>
+        <Description>Description of the category</Description>
+        <IsEnabled>1</IsEnabled>
+      </PostCategory>
+    </Post>
+    ...
+
+
 #### embedded_relations_hide
 
 You may want to hide some fields from the embedded relations. For instance,

--- a/README.markdown
+++ b/README.markdown
@@ -341,6 +341,38 @@ Several things to consider:
   * The response contains both the `PostCategoryId` field and the `PostCategory.Id` fields. You can save some bytes by using the `display` or the `hide` options, in order to remove the `PostCategoryId` field.
 
 
+#### embed_relations_custom
+
+The `embed_relations_custom` option contains a list of Doctrine relations that
+may be embedded. These relations will only be embedded if the `embed` parameter
+is present in the request. The behavior is consistent with the `embed_relations`
+option. Here is a valid configuration for our "Post" model:
+
+            config:
+              get:
+                embed_relations_custom:                [ PostCategory ]
+
+If the `embed` request parameter is given, this configuration will produce a
+feed like:
+
+    ...
+    <Post>
+      <Id>1</Id>
+      <PostCategoryId>2</PostCategoryId>
+      <CreatedBy>26</CreatedBy>
+      <Title>Here the title of my post</Title>
+      <Summary>Here the summary of my post</Summary>
+      <Body>Here the body of my post</Body>
+      <PostCategory>
+        <Id>2</Id>
+        <Name>Name of the category</Name>
+        <Description>Description of the category</Description>
+        <IsEnabled>1</IsEnabled>
+      </PostCategory>
+    </Post>
+    ...
+
+
 #### embedded_relations_hide
 
 You may want to hide some fields from the embedded relations. For instance,

--- a/data/generator/sfDoctrineRestGenerator/default/parts/configuration.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/configuration.php
@@ -34,6 +34,12 @@ abstract class Base<?php echo ucfirst($this->getModuleName()) ?>GeneratorConfigu
 <?php unset($this->config['get']['embed_relations']) ?>
   }
 
+  public function getEmbedRelationsCustom()
+  {
+    return <?php echo $this->asPhp(isset($this->config['get']['embed_relations_custom']) ? $this->config['get']['embed_relations_custom'] : array()) ?>;
+<?php unset($this->config['get']['embed_relations_custom']) ?>
+  }
+
   public function getEmbeddedRelationsHide()
   {
     $embedded_relations_hide = <?php echo $this->asPhp(isset($this->config['get']['embedded_relations_hide']) ? $this->config['get']['embedded_relations_hide'] : array()) ?>;

--- a/data/generator/sfDoctrineRestGenerator/default/parts/getIndexValidators.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/getIndexValidators.php
@@ -34,6 +34,13 @@ $max_items = $this->configuration->getValue('get.max_items'); ?>
     $validators['<?php echo $param; ?>'] = new sfValidatorPass(array('required' => false));
 <?php endforeach; ?>
 <?php endif; ?>
+<?php $embed_relations_custom = $this->configuration->getValue('get.embed_relations_custom'); ?>
+<?php if ($embed_relations_custom): ?>
+    $validators['embed'] = new sfValidatorChoice(array(
+        'required' => false,
+        'choices' => <?php echo var_export($embed_relations_custom); ?>,
+    ));
+<?php endif; ?>
 
     return $validators;
   }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/getIndexValidators.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/getIndexValidators.php
@@ -36,9 +36,16 @@ $max_items = $this->configuration->getValue('get.max_items'); ?>
 <?php endif; ?>
 <?php $embed_relations_custom = $this->configuration->getValue('get.embed_relations_custom'); ?>
 <?php if ($embed_relations_custom): ?>
-    $validators['embed'] = new sfValidatorChoice(array(
+    $validators['embed'] = new sfValidatorCallback(array(
         'required' => false,
-        'choices' => <?php echo var_export($embed_relations_custom); ?>,
+        'callback' => function ($validator, $input) {
+            foreach (explode('<?php echo $this->configuration->getValue('default.separator'); ?>', $input) as $embed) {
+                if (!in_array($embed, <?php echo var_export($embed_relations_custom); ?>)) {
+                    throw new sfValidatorError($validator, '"' . $embed . '" is not embeddable');
+                }
+            }
+            return $input;
+        },
     ));
 <?php endif; ?>
 

--- a/data/generator/sfDoctrineRestGenerator/default/parts/query.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/query.php
@@ -28,6 +28,7 @@ foreach ($embed_relations as $relation_name)
 <?php if (!$this->isManyToManyRelation($embed_relation)): ?>
 
       ->leftJoin($this->model.'.<?php echo $embed_relation ?> <?php echo $embed_relation ?>')<?php endif; ?><?php endforeach; ?>;
+<?php if ($embed_relations_custom): ?>
     if (isset($params['embed']))
     {
         $embed_relations = explode('<?php echo $this->configuration->getValue('default.separator', ',') ?>', $params['embed']);
@@ -42,6 +43,7 @@ foreach ($embed_relations as $relation_name)
 <?php endforeach; ?>
         unset($params['embed']);
     }
+<?php endif; ?>
 
 <?php
 $max_items = $this->configuration->getValue('get.max_items');

--- a/data/generator/sfDoctrineRestGenerator/default/parts/query.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/query.php
@@ -10,6 +10,7 @@
 <?php
 $display = $this->configuration->getValue('get.display');
 $embed_relations = $this->configuration->getValue('get.embed_relations');
+$embed_relations_custom = $this->configuration->getValue('get.embed_relations_custom');
 
 $fields = $display;
 foreach ($embed_relations as $relation_name)
@@ -27,6 +28,20 @@ foreach ($embed_relations as $relation_name)
 <?php if (!$this->isManyToManyRelation($embed_relation)): ?>
 
       ->leftJoin($this->model.'.<?php echo $embed_relation ?> <?php echo $embed_relation ?>')<?php endif; ?><?php endforeach; ?>;
+    if (isset($params['embed']))
+    {
+        $embed_relations = explode('<?php echo $this->configuration->getValue('default.separator', ',') ?>', $params['embed']);
+
+<?php foreach ($embed_relations_custom as $embed_relation): ?>
+<?php if (!$this->isManyToManyRelation($embed_relation)): ?>
+        if (in_array('<?php echo $embed_relation; ?>', $embed_relations))
+        {
+            $q->leftJoin($this->model.'.<?php echo $embed_relation ?> <?php echo $embed_relation ?>');
+        }
+<?php endif; ?>
+<?php endforeach; ?>
+        unset($params['embed']);
+    }
 
 <?php
 $max_items = $this->configuration->getValue('get.max_items');

--- a/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
+++ b/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
@@ -15,6 +15,7 @@ generator:
 #        default_format:                json    # the default format of the response. If not set, will default to json. accepted values are "json", "xml" or "yaml"
 #        display:                       []      # list here the fields to render in the response
 #        embed_relations:               []      # list here relations to embed in the response
+#        embed_relations_custom:        []      # list here relations to embed in the response if the embed request parameter is set
 #        embedded_relations_hide:
 #          Category:                    [id]    # you can hide fields inside a certain embedded relation
 #        global_additional_fields:      []      # list here additionnal calculated global fields

--- a/lib/generator/sfDoctrineRestGeneratorConfiguration.class.php
+++ b/lib/generator/sfDoctrineRestGeneratorConfiguration.class.php
@@ -27,6 +27,7 @@ class sfDoctrineRestGeneratorConfiguration
         'default_format'              => $this->getDefaultFormat(),
         'display'                     => $this->getDisplay(),
         'embed_relations'             => $this->getEmbedRelations(),
+        'embed_relations_custom'      => $this->getEmbedRelationsCustom(),
         'embedded_relations_hide'     => $this->getEmbeddedRelationsHide(),
         'fields'                      => $this->getFieldsGet(),
         'filters'                     => $this->getFilters(),


### PR DESCRIPTION
this patchset enables the `embed_relations_custom` option for generator config files. This option allows certain relations to be embedded, but only if the embed request parameter is set by the caller.
