### PR TITLE
Use Class name instead of Alias name for Validators

### DIFF
--- a/lib/generator/sfDoctrineRestGenerator.class.php
+++ b/lib/generator/sfDoctrineRestGenerator.class.php
@@ -741,7 +741,7 @@ class sfDoctrineRestGenerator extends sfGenerator
 
     if ($column->isForeignKey())
     {
-      $options[] = sprintf('\'model\' => Doctrine_Core::getTable('.$model.')->getRelation(\'%s\')->getAlias()', $column->getRelationKey('alias'));
+      $options[] = sprintf('\'model\' => Doctrine_Core::getTable('.$model.')->getRelation(\'%s\')->getTable()->getComponentName()', $column->getRelationKey('alias'));
     }
     else if ($column->isPrimaryKey())
     {


### PR DESCRIPTION
As mentioned in https://github.com/xavierlacot/sfDoctrineRestGeneratorPlugin/pull/27#issuecomment-32468669 , the default create validators error when the doctrine relation alias is not equal to the doctrine object name.
This PR uses the doctrine component name instead of the relation alias, fixing the mentioned problem.
