### PR TITLE
Disabling create validators via generator configuration

### DIFF
--- a/README
+++ b/README
@@ -201,6 +201,8 @@ Here is the default content of the `generator.yml` file:
         #        sort_default:                  []      # set to [column, asc|desc] in order to sort on a column
         #        filters:                               # list here the filters
         #          created_at:                  { date_format: 'd-m-Y', multiple: true }  # for instance
+              create:
+        #        disable_validators:            [ created_at ] # list here validators that should not be generated
 
 The different possible parameters, commented in the previous sample, are
 detailed in the following chapters.
@@ -503,6 +505,20 @@ accepted. For example:
               get:
                 filters:
                   created_at:                  { date_format: 'd-m-Y' }
+
+### create
+
+The `create` option lists several options specific to the "create" operation:
+
+#### disable_validators
+
+The `disable_validators` options contains the list of field names for which
+create validators should not be generated. For example:
+
+            config:
+              create:
+                disable_validators:            [ created_at, updated_at ]
+
 
 ### Other configuration variables
 

--- a/README.markdown
+++ b/README.markdown
@@ -201,6 +201,8 @@ Here is the default content of the `generator.yml` file:
         #        sort_default:                  []      # set to [column, asc|desc] in order to sort on a column
         #        filters:                               # list here the filters
         #          created_at:                  { date_format: 'd-m-Y', multiple: true }  # for instance
+              create:
+        #        disable_validators:            [ created_at ] # list here validators that should not be generated
 
 The different possible parameters, commented in the previous sample, are
 detailed in the following chapters.
@@ -503,6 +505,20 @@ accepted. For example:
               get:
                 filters:
                   created_at:                  { date_format: 'd-m-Y' }
+
+### create
+
+The `create` option lists several options specific to the "create" operation:
+
+#### disable_validators
+
+The `disable_validators` options contains the list of field names for which
+create validators should not be generated. For example:
+
+            config:
+              create:
+                disable_validators:            [ created_at, updated_at ]
+
 
 ### Other configuration variables
 

--- a/data/generator/sfDoctrineRestGenerator/default/parts/configuration.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/configuration.php
@@ -94,4 +94,6 @@ abstract class Base<?php echo ucfirst($this->getModuleName()) ?>GeneratorConfigu
 <?php include dirname(__FILE__).'/paginationConfiguration.php' ?>
 
 <?php include dirname(__FILE__).'/sortConfiguration.php' ?>
+
+<?php include dirname(__FILE__).'/createConfiguration.php' ?>
 }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/createConfiguration.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/createConfiguration.php
@@ -1,0 +1,5 @@
+  public function getDisableCreateValidators()
+  {
+    return <?php echo $this->asPhp(isset($this->config['create']['disable_validators']) ? $this->config['create']['disable_validators'] : array()) ?>;
+<?php unset($this->config['create']['disable_validators']) ?>
+  }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/getCreateValidators.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/getCreateValidators.php
@@ -4,5 +4,5 @@
    */
   public function getCreateValidators()
   {
-    return <?php echo $this->getCreateValidatorsArray($this); ?>;
+    return <?php echo $this->getCreateValidatorsArray($this, 0, $this->configuration->getValue('create.disable_validators')); ?>;
   }

--- a/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
+++ b/data/generator/sfDoctrineRestGenerator/default/skeleton/config/generator.yml
@@ -28,3 +28,5 @@ generator:
 #        sort_default:                  []      # set to [column, asc|desc] in order to sort on a column
 #        filters:                               # list here the filters
 #          created_at:                  { date_format: 'd-m-Y', multiple: true }  # for instance
+      create:
+#        disable_validators: [ created_at ]

--- a/lib/generator/sfDoctrineRestGenerator.class.php
+++ b/lib/generator/sfDoctrineRestGenerator.class.php
@@ -788,7 +788,7 @@ class sfDoctrineRestGenerator extends sfGenerator
    * array of validators in a smiliar arrangement like the relationships
    * hierarchy.
    */
-  protected function getCreateValidatorsArray($table, $level = 0)
+  protected function getCreateValidatorsArray($table, $level = 0, $disabled_validators = array())
   {
     if ($level > 1)
     {
@@ -807,7 +807,7 @@ class sfDoctrineRestGenerator extends sfGenerator
 
     foreach ($this->getColumns($table) as $column)
     {
-      if (!$column->isPrimaryKey())
+      if (!$column->isPrimaryKey() && !in_array($column->getFieldName(), $disabled_validators))
       {
         $validators .= $spaces.'\''.$column->getFieldName().'\' => new '.$this->getCreateValidatorClassForColumn($column).'('.$this->getCreateValidatorOptionsForColumn($column, $model_name)."),\n";
       }
@@ -819,7 +819,7 @@ class sfDoctrineRestGenerator extends sfGenerator
       {
         // to do later
       }
-      else
+      elseif (!in_array($alias, $disabled_validators))
       {
         $sub_validators = $this->getCreateValidatorsArray($relation->getTable(), $level + 1);
 

--- a/lib/generator/sfDoctrineRestGeneratorConfiguration.class.php
+++ b/lib/generator/sfDoctrineRestGeneratorConfiguration.class.php
@@ -39,7 +39,10 @@ class sfDoctrineRestGeneratorConfiguration
         'pagination_page_size'        => $this->getPaginationPageSize(),
         'sort_custom'                 => $this->getSortCustom(),
         'sort_default'                => $this->getSortDefault()
-      )
+      ),
+      'create'  => array(
+        'disable_validators'          => $this->getDisableCreateValidators(),
+      ),
     );
   }
 


### PR DESCRIPTION
This pull request introduces the `create.disable_validators` configuration directive. This directive allows to disable the generation of certain create validators. This solves the problem of @beoboo described and fixes xavierlacot/sfDoctrineRestGeneratorPlugin#4
