### PR TITLE
Don't send decoding error on empty json object

### DIFF
--- a/data/generator/sfDoctrineRestGenerator/default/parts/parsePayload.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/parsePayload.php
@@ -10,7 +10,7 @@
         $payload_array = $serializer->unserialize($payload);
       }
 
-      if (!isset($payload_array) || !$payload_array)
+      if (!isset($payload_array) || $payload_array === false)
       {
         throw new sfException(sprintf('Could not parse payload, obviously not a valid %s data!', $format));
       }

--- a/data/generator/sfDoctrineRestGenerator/default/parts/parsePayload.php
+++ b/data/generator/sfDoctrineRestGenerator/default/parts/parsePayload.php
@@ -12,7 +12,7 @@
 
       if (!isset($payload_array) || $payload_array === false)
       {
-        throw new sfException(sprintf('Could not parse payload, obviously not a valid %s data!', $format));
+        throw new sfException(sprintf('Could not parse payload, not valid %s data', $format));
       }
 
       $filter_params = <?php var_export(array_flip(array_merge(


### PR DESCRIPTION
When the payload PUT or POST requests is an empty JSON object (`{}`), the REST module throws an exception (yielding a 500 Internal Server Error at the HTTP level) with the message that the payload is not valid JSON. `{}` however is valid JSON, and `json_decode` returns an empty array.
Since `array()` is falsy in PHP, the error was triggered incorrectly. Comparing with `===` solves this
